### PR TITLE
updata

### DIFF
--- a/dao/Test/test.go
+++ b/dao/Test/test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	// "database/sql"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/lingfliu/ucs_core/dao"
+	"github.com/lingfliu/ucs_core/dao/impl"
+	"github.com/lingfliu/ucs_core/data/rtdb"
+	"github.com/lingfliu/ucs_core/dd"
+	"github.com/lingfliu/ucs_core/model"
+	"github.com/lingfliu/ucs_core/model/msg"
+
+	//"github.com/lingfliu/ucs_core/model/spec"
+	"github.com/lingfliu/ucs_core/ulog"
+	"github.com/lingfliu/ucs_core/utils"
+	_ "github.com/taosdata/driver-go/v3/taosSql"
+)
+
+type MqttCfg struct {
+	Host      string
+	Port      int
+	Username  string
+	Password  string
+	TopicList []string
+	Qos       byte
+	Timeout   int
+}
+
+var mqttCfg = &MqttCfg{
+	Host:      "62.234.16.239",
+	Port:      1883,
+	Username:  "admin",
+	Password:  "admin1234",
+	TopicList: []string{"ucs/dd/tehu_node"},
+	Qos:       0,
+	Timeout:   3000,
+}
+
+const (
+	TAOS_HOST     = "62.234.16.239:6030"
+	TAOS_DATABASE = "ucs"
+	TAOS_USERNAME = "root"
+	TAOS_PASSWORD = "taosdata"
+)
+
+func main() {
+	//config log
+	ulog.Config(ulog.LOG_LEVEL_INFO, "./log.log", false)
+
+	// open mqttCli
+	mqttCli := dd.NewMqttCli(utils.IpPortJoin(mqttCfg.Host, mqttCfg.Port), mqttCfg.Username, mqttCfg.Password, mqttCfg.TopicList, mqttCfg.Qos, mqttCfg.Timeout)
+	mqttCli.Start()
+	fmt.Println("MQTT client started")
+
+	//config taos
+	taosCli := rtdb.NewTaosCli(TAOS_HOST, TAOS_DATABASE, TAOS_USERNAME, TAOS_PASSWORD)
+	log.Println("Opening database connection...")
+	taosCli.Open()
+
+	// 实例化 TehuNodeDao
+	template := model.DPoint{}
+	colNameList := []string{"temp", "humi"}
+	dpDao := &dao.DpDao{
+		TaosCli:     taosCli,
+		Template:    &template,
+		ColNameList: colNameList,
+	}
+	tehuNodeDao := &impl.TehuNodeDao{
+		DpDao: *dpDao,
+	}
+	fmt.Printf("TehuNodeDao created: %+v\n", tehuNodeDao)
+
+	node := tehuNodeDao.GenerateTemplate()
+	fmt.Printf("Generated node: %+v\n", node)
+
+	// 调用 Create 函数
+	res := tehuNodeDao.Create()
+	if res < 0 {
+		log.Println("Failed to create stable.")
+	} else {
+		log.Println("Stable created successfully.")
+		defer dpDao.TaosCli.Close() // 确保在退出时关闭连接
+	}
+	//调用 TableExist 方法
+	exists := tehuNodeDao.TableExist()
+	if exists {
+		fmt.Println("所有表存在")
+	} else {
+		fmt.Println("有表不存在")
+	}
+
+	sigRun, cancelRun := context.WithCancel(context.Background())
+	go _task_mqtt_io(sigRun, mqttCli)
+
+	fmt.Println("========= MQTT 客户端连接成功===============")
+
+	go _task_recv_mqtt(sigRun, mqttCli, tehuNodeDao)
+
+	//等待退出信号，并在收到信号时断开连接
+	s := make(chan os.Signal, 1)
+	signal.Notify(s, os.Interrupt)
+	for {
+		select {
+		case <-s:
+			cancelRun()
+			mqttCli.Stop()
+			dpDao.Close()
+			return
+		default:
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+// 处理 MQTT 客户端的连接状态
+func _task_mqtt_io(sigRun context.Context, mqttCli *dd.MqttCli) {
+	for state := range mqttCli.Io {
+		if state == dd.DD_STATE_CONNECTED {
+			ulog.Log().I("main", "mqtt connected")
+		} else if state == dd.DD_STATE_DISCONNECTED {
+			ulog.Log().I("main", "mqtt disconnected")
+		}
+	}
+}
+
+func _task_recv_mqtt(sigRun context.Context, mqttCli *dd.MqttCli, tehuNodeDao *impl.TehuNodeDao) {
+	//Subscribe( mqtt message
+	for _, topic := range mqttCfg.TopicList {
+		if result := mqttCli.Subscribe(topic); result != 0 {
+			log.Println("Failed to subscribe to topic:", topic)
+		} else {
+			log.Println("Successfully subscribed to topic:", topic)
+		}
+	}
+	// Add a ticker for logging if no messages are received
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sigRun.Done():
+			fmt.Println("Signal received, terminating loop.")
+			return
+		case rxmsg := <-mqttCli.RxMsg:
+			fmt.Println("=========接收MQTT消息=================")
+			fmt.Printf("Received message on topic: " + rxmsg.Topic + ", Data: " + string(rxmsg.Data))
+			//ulog.Log().I("main", "Received message on topic: "+rxmsg.Topic+", Data: "+string(rxmsg.Data))
+			//parse mqtt message
+			switch rxmsg.Topic {
+			case "ucs/dd/tehu_node":
+				//payload is encoded by DpCoder: [ts, dnode id, dp offsetidx, int value]
+				dpMsg := &msg.DMsg{}
+				err := json.Unmarshal(rxmsg.Data, dpMsg)
+				if err != nil {
+					ulog.Log().E("main", "th_node msg decode error: "+err.Error())
+				} else {
+					ulog.Log().I("main", fmt.Sprintf("Decoded dpMsg: %+v", dpMsg))
+					ulog.Log().I("main", fmt.Sprintf("DNodeId: %d, Offset: %d, DataSet: %+v", dpMsg.DNodeId, dpMsg.Offset, dpMsg.DataSet))
+					//insert into taos
+					ulog.Log().I("main", "insert tehu_node msg: "+string(rxmsg.Data))
+					tehuNodeDao.Insert(dpMsg)
+					//dpDao.Insert(dpMsg)
+				}
+			default:
+				log.Printf("Message received on unexpected topic: %s, Data: %s", rxmsg.Topic, string(rxmsg.Data))
+			}
+		case <-ticker.C:
+			fmt.Println("No message received in the last 5 seconds.")
+		default:
+			time.Sleep(time.Second * 1)
+		}
+	}
+}

--- a/dao/dp_dao.go
+++ b/dao/dp_dao.go
@@ -20,12 +20,12 @@ import (
  * 标签: dnode_id bigint | dpoint_id bigint | pos varchar
  */
 type DpDao struct {
-	ColNameList string[]
-	Template *model.DPoint
-	TaosCli *rtdb.TaosCli
+	ColNameList []string
+	Template    *model.DPoint
+	TaosCli     *rtdb.TaosCli
 }
 
-func NewDpDao(host string, dbName string, username string, password string, template model.DPoint, colNameList string[]) *DpDao {
+func NewDpDao(host string, dbName string, username string, password string, template model.DPoint, colNameList []string) *DpDao {
 	return &DpDao{TaosCli: rtdb.NewTaosCli(host, dbName, username, password)}
 }
 
@@ -33,7 +33,7 @@ func (dao *DpDao) Open() {
 	dao.TaosCli.Open()
 }
 
-func (dao *DpDao) Init() {
+// func (dao *DpDao) Init() {
 func (dao *DpDao) TableExist(tableName string) bool {
 	sql := fmt.Sprintf("show tables like '%s'", tableName)
 	rows := dao.TaosCli.Query(sql)

--- a/dao/impl/tehu_node_dao.go
+++ b/dao/impl/tehu_node_dao.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lingfliu/ucs_core/dao"
 	"github.com/lingfliu/ucs_core/model"
 	"github.com/lingfliu/ucs_core/model/meta"
+	"github.com/lingfliu/ucs_core/model/msg"
 	"github.com/lingfliu/ucs_core/ulog"
 )
 
@@ -70,6 +71,19 @@ func (dao *TehuNodeDao) GenerateTemplate() *model.DNode {
 	return tehuNode
 }
 
+func (dao *TehuNodeDao) Create() int {
+
+	sql := fmt.Sprintf("create stable if not exists %s (ts timestamp, temp int, humi int) tags (dnode_id int, dnode_offset int)", stableName)
+	res := dao.TaosCli.Exec(sql)
+	if res < 0 {
+		ulog.Log().E("dpdao", fmt.Sprintf("failed to create stable %s", stableName))
+	} else {
+		ulog.Log().I("dpdao", fmt.Sprintf("create stable %s success", stableName))
+	}
+
+	return res
+}
+
 func (d *TehuNodeDao) TableExist() bool {
 	for _, v := range d.GenerateTemplate().DPointSet {
 		if !d.DpDao.TableExist(fmt.Sprintf("%s_%d_%d", stableName, v.NodeId, v.Offset)) {
@@ -96,13 +110,33 @@ func (d *TehuNodeDao) InitTable() int {
 	return 0
 }
 
-func (dao *TehuNodeDao) Insert(p *model.DPoint) {
-	//子表命名方式 ${stablename}_${nodeid}_${dp_offset}
-	temp := binary.BigEndian.Uint32(p.Data[:3])
-	humi := binary.BigEndian.Uint32(p.Data[4:])
-	tableName := fmt.Sprintf("%s_%d_%d", stableName, p.NodeId, p.Offset)
-	sql := fmt.Sprintf("insert into %s using %s values(?, ?, ?) tags(?, ?)", tableName, stableName)
-	dao.TaosCli.Exec(sql, p.Ts, int(temp), int(humi), p.NodeId, p.Offset)
+// func (dao *TehuNodeDao) Insert(p *model.DPoint) {
+// 	//子表命名方式 ${stablename}_${nodeid}_${dp_offset}
+// 	temp := binary.BigEndian.Uint32(p.Data[:3])
+// 	humi := binary.BigEndian.Uint32(p.Data[4:])
+// 	tableName := fmt.Sprintf("%s_%d_%d", stableName, p.NodeId, p.Offset)
+// 	sql := fmt.Sprintf("insert into %s using %s values(?, ?, ?) tags(?, ?)", tableName, stableName)
+// 	dao.TaosCli.Exec(sql, p.Ts, int(temp), int(humi), p.NodeId, p.Offset)
+// }
+
+func (dao *TehuNodeDao) Insert(p *msg.DMsg) {
+	//表名${stablename}_${DNodeId}_${Offset}
+	tableName := fmt.Sprintf("%s_%d_%d", stableName, p.DNodeId, p.Offset)
+	var temp, humi uint32
+	// 遍历 DataSet 以提取温度和湿度
+	for i, DMsgData := range p.DataSet {
+		if DMsgData.Meta.Dimen == 1 {
+			value := binary.BigEndian.Uint32(DMsgData.Data[0:4])
+			if i == 0 {
+				temp = value // 第一个数据点为温度
+			} else if i == 1 {
+				humi = value // 第二个数据点为湿度
+			}
+		}
+	}
+	insertSQL := fmt.Sprintf("insert into %s using %s TAGS (%d, %d) VALUES (NOW(), %d, %d)", tableName, stableName, p.DNodeId, p.Offset, temp, humi)
+	fmt.Println("[SQL]" + insertSQL)
+	dao.TaosCli.Exec(insertSQL)
 }
 
 func (dao *TehuNodeDao) Query(nodeId int, tic int64, toc int64) []*model.DPoint {

--- a/dao/mock/tehu_mock.go
+++ b/dao/mock/tehu_mock.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/lingfliu/ucs_core/dd"
+	"github.com/lingfliu/ucs_core/model/meta"
+	"github.com/lingfliu/ucs_core/model/msg"
+	"github.com/lingfliu/ucs_core/ulog"
+	"github.com/lingfliu/ucs_core/utils"
+)
+
+const (
+	MQTT_HOST     = "62.234.16.239"
+	MQTT_PORT     = 1883
+	MQTT_TOPIC    = "ucs/dd/tehu_node"
+	MQTT_USERNAME = "admin"
+	MQTT_PASSWORD = "admin1234"
+
+	DATA_DIMEN   = 1
+	DATA_BYTELEN = 4 //int16
+)
+
+type DNodeMock struct {
+	Class   int64
+	Id      int64
+	NoDp    int
+	DpDimen int
+	Cli     *dd.MqttCli
+}
+
+func main() {
+	//config log
+	ulog.Config(ulog.LOG_LEVEL_INFO, "./log.log", false)
+
+	nodeList := make([]*DNodeMock, 0)
+	ctlRunList := make([]context.CancelFunc, 0)
+	for i := 0; i < 5; i++ {
+		//定义5个DNode，每个DNode包含2个DPoint
+		cli := dd.NewMqttCli(utils.IpPortJoin(MQTT_HOST, MQTT_PORT),
+			MQTT_USERNAME,
+			MQTT_PASSWORD,
+			[]string{MQTT_TOPIC},
+			0,
+			3000)
+		dnode := &DNodeMock{
+			Class:   int64(i),
+			Id:      int64(i),
+			NoDp:    2,
+			DpDimen: DATA_DIMEN,
+			Cli:     cli,
+		}
+
+		nodeList = append(nodeList, dnode)
+		sigRun, ctlRun := context.WithCancel(context.Background())
+		ctlRunList = append(ctlRunList, ctlRun)
+		go _task_mock_mqtt(sigRun, dnode)
+	}
+
+	go _task_cancel(ctlRunList)
+
+	s := make(chan os.Signal, 1)
+	signal.Notify(s, os.Interrupt)
+	for {
+		select {
+		case <-s:
+			return
+		default:
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+}
+
+func _task_cancel(ctlRunList []context.CancelFunc) {
+	time.Sleep(15 * time.Second)
+	for _, ctlRun := range ctlRunList {
+		ctlRun()
+	}
+	ulog.Log().I("mock", "all tasks canceled")
+}
+
+func _task_mock_mqtt(sigRun context.Context, dnode *DNodeMock) {
+	dnode.Cli.Start()
+	tic := time.NewTicker(5 * time.Second) //每5秒生成一次数据
+
+	// go func() {
+	// 	dnode.Cli.Subscribe(MQTT_TOPIC)
+	// }()
+
+	for {
+		select {
+		case <-sigRun.Done():
+			dnode.Cli.Stop()
+		case <-tic.C:
+			if sigRun.Err() != nil {
+				ulog.Log().I("mock", "task is canceled, stopping publish")
+				return
+			}
+			for i := 0; i < dnode.NoDp; i++ {
+				//模拟部分：NoDp=2, sampleLen=1，dimen=1，bytelen=4， MSB，随机数据
+				dmsg := &msg.DMsg{
+					Ts:      time.Now().UnixNano() / 1e6, //当前时间戳，单位为毫秒
+					Sps:     100 * 1000 * 1000,           //采样率
+					Mode:    0,                           //0-定时采样，1-事件触发，2-轮询
+					DNodeId: dnode.Id,                    // 节点ID
+					DataSet: make(map[int]*msg.DMsgData),
+				}
+
+				valueList := make([]byte, dnode.DpDimen*4)
+				if i == 0 {
+					// 模拟生成温度数据 (维度0)
+					temp := utils.RandInt32(0, 50)                              // 随机生成温度范围0°C到50°C
+					binary.BigEndian.PutUint32(valueList[0:4], uint32(temp))    // 将温度值放入第0个维度
+					ulog.Log().I("mock", fmt.Sprintf("publish temp: %d", temp)) // 打印温度值
+
+					dmsg.Offset = 0
+					dmsg.DataSet[dmsg.Offset] = &msg.DMsgData{
+						Meta: &meta.DataMeta{
+							Dimen:     1, // 维度
+							SampleLen: 1, // 采样长度
+							ByteLen:   4, // uint32 占用 4 字节
+							DataClass: meta.DATA_CLASS_INT,
+							Alias:     "Temperature",
+							Unit:      "°C",
+						},
+						Data: valueList,
+					}
+
+				} else if i == 1 {
+					// 模拟生成湿度数据 (维度1)
+					humi := utils.RandInt32(20, 70)                             // 随机生成湿度范围20%到70%
+					binary.BigEndian.PutUint32(valueList[0:4], uint32(humi))    // 将湿度值放入第1个维度
+					ulog.Log().I("mock", fmt.Sprintf("publish humi: %d", humi)) // 打印湿度值
+
+					dmsg.Offset = 1
+					dmsg.DataSet[dmsg.Offset] = &msg.DMsgData{
+						Meta: &meta.DataMeta{
+							Dimen:     DATA_DIMEN, //1
+							SampleLen: 1,
+							ByteLen:   DATA_BYTELEN, // uint32 占用 4 字节
+							DataClass: meta.DATA_CLASS_INT,
+							Alias:     "Humidity",
+							Unit:      "%",
+						},
+						Data: valueList,
+					}
+					//指定维度，不用循环
+					// for i := 0; i < dnode.DpDimen; i++ {
+					// 	//random int32
+					// 	v := utils.RandInt32(0, 10000)
+					// 	binary.BigEndian.PutUint32(valueList[i*4:(i+1)*4], uint32(v))
+					// 	// 打印温湿度值
+					// 	ulog.Log().I("mock", fmt.Sprintf("publish temp and humi: %d", uint32(v)))
+					// }
+
+				}
+				// 将数据转换为 JSON 并发布到 MQTT
+				bytes, err := json.Marshal(dmsg)
+				if err != nil {
+					ulog.Log().E("mock", "failed to marshal ddMsg, err: "+err.Error())
+					continue
+				}
+				ulog.Log().I("mock", "------------------>publish tehu msg: "+string(bytes))
+				dnode.Cli.Publish(MQTT_TOPIC, bytes)
+				//fmt.Println("Publishing to MQTT topic: ucs/dd/th_node, Data:", bytes)
+
+			}
+		}
+	}
+}

--- a/dd/mqtt_cli.go
+++ b/dd/mqtt_cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"time"
@@ -128,6 +129,14 @@ func (cli *MqttCli) Publish(topic string, data []byte) {
 
 	if token := cli.mc.Publish(topic, cli.Qos, false, data); token.WaitTimeout(time.Duration(cli.Timeout*int(time.Millisecond))) && token.Error() != nil {
 		cli.Disconnect()
+		ulog.Log().E("mqtt", "Failed to publish message to topic "+topic+": "+token.Error().Error())
+	} else {
+		fmt.Printf("publish message on Message: %s\n", data)
+		cli.RxMsg <- &DdZeroMsg{
+			Topic: topic,
+			Data:  data,
+		}
+		ulog.Log().I("mqtt", "Published message to topic "+topic)
 	}
 }
 

--- a/model/d_point.go
+++ b/model/d_point.go
@@ -6,10 +6,10 @@ import (
 
 type DPoint struct {
 	//1. 寻址， 2. 静态属性， 3. Node信息, 4. 数据Meta， 5. 数据
-	Id    int64
-	Class string //数据点位类别
-	// Name   string //数据点位名称
-	Offset int //索引 (总线地址)
+	Id     int64
+	Class  string //数据点位类别
+	Name   string //数据点位名称
+	Offset int    //索引 (总线地址)
 
 	NodeId    int64
 	NodeName  string //alternative of NodeId for display

--- a/model/meta/data_meta.go
+++ b/model/meta/data_meta.go
@@ -3,19 +3,24 @@ package meta
 import "encoding/binary"
 
 const (
-	DATA_CLASS_RAW   = 0 //raw bytes or ASCII byte strings
-	DATA_CLASS_INT8   = 1
-	DATA_CLASS_UINT8   = 2
-	DATA_CLASS_INT16   = 3
-	DATA_CLASS_UINT16   = 4
-	DATA_CLASS_INT32   = 5
-	DATA_CLASS_UINT32   = 6
-	DATA_CLASS_INT64  = 7
-	DATA_CLASS_UINT64  = 8
-	DATA_CLASS_FLOAT = 9
-	DATA_CLASS_DOUBLE = 10
-	DATA_CLASS_FLAG  = 11
-	DATA_CLASS_JSON  = 12 //UTF-8 format json string (used in for url fetching)
+	// DATA_CLASS_RAW   = 0 //raw bytes or ASCII byte strings
+	// DATA_CLASS_INT8   = 1
+	// DATA_CLASS_UINT8   = 2
+	// DATA_CLASS_INT16   = 3
+	// DATA_CLASS_UINT16   = 4
+	// DATA_CLASS_INT32   = 5
+	// DATA_CLASS_UINT32   = 6
+	// DATA_CLASS_INT64  = 7
+	// DATA_CLASS_UINT64  = 8
+	// DATA_CLASS_FLOAT = 9
+	// DATA_CLASS_DOUBLE = 10
+	// DATA_CLASS_FLAG  = 11
+	// DATA_CLASS_JSON  = 12 //UTF-8 format json string (used in for url fetching)
+	DATA_CLASS_RAW   = 0 //raw bytes
+	DATA_CLASS_INT   = 1
+	DATA_CLASS_UINT  = 2
+	DATA_CLASS_FLOAT = 3
+	DATA_CLASS_FLAG  = 4
 )
 
 /**
@@ -26,14 +31,14 @@ type DataMeta struct {
 	Dimen     int
 	SampleLen int
 	Alias     string //代号
-	Code string //代码
+	Code      string //代码
 	Unit      string //单位
 	DataClass int
 	Msb       bool
 }
 
 //TODO: remove on release
-func (meta *DataMeta) Convert(raw []byte) []any {
+func (meta *DataMeta) Convert(raw []byte, byteLen int, dimen int, class int) []any {
 	data := make([]any, dimen)
 	switch class {
 	case DATA_CLASS_RAW:


### PR DESCRIPTION
dao/impl/tehu_node_dao.go：新增了create方法，修改了Insert方法；
dao/mock/tehu_mock.go：仿真mqtt发送温湿度节点的数据；
dao/mock/test,go：测试mqtt发送数据—插入到taos数据库中的链路；
model/d_point.go：取消了DPoint中name的注释
model/meta/data_meta.go：注释了DATA_CLASS类型的部分常量，因为后续代码并未对这些常量做说明，导致调用函数报错，所以还是沿用了之前的DATA_CLASS类型。

